### PR TITLE
Fixed an issue where Lucene.net assembly could not be found

### DIFF
--- a/src/Augurk.Api/Properties/AssemblyInfo.cs
+++ b/src/Augurk.Api/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Augurk.Api")]
-[assembly: AssemblyCopyright("Copyright 2014 - 2015, Mark Taling")]
+[assembly: AssemblyCopyright("Copyright 2014 - 2017, Augurk")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Augurk.Entities/Properties/AssemblyInfo.cs
+++ b/src/Augurk.Entities/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Augurk.Entities")]
-[assembly: AssemblyCopyright("Copyright 2014 - 2015, Mark Taling")]
+[assembly: AssemblyCopyright("Copyright 2014 - 2017, Augurk")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Augurk.MSBuild.UnitTest/Properties/AssemblyInfo.cs
+++ b/src/Augurk.MSBuild.UnitTest/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Augurk.MSBuild.UnitTest")]
-[assembly: AssemblyCopyright("Copyright 2014 - 2015, Mark Taling")]
+[assembly: AssemblyCopyright("Copyright 2014 - 2017, Augurk")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Augurk.MSBuild/Properties/AssemblyInfo.cs
+++ b/src/Augurk.MSBuild/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Augurk.MSBuild")]
-[assembly: AssemblyCopyright("Copyright 2014 - 2015, Mark Taling")]
+[assembly: AssemblyCopyright("Copyright 2014 - 2017, Augurk")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Augurk.Specifications/Augurk.Specifications.csproj
+++ b/src/Augurk.Specifications/Augurk.Specifications.csproj
@@ -54,6 +54,9 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="..\Augurk\Properties\AssemblyVersion.cs">
+      <Link>Properties\AssemblyVersion.cs</Link>
+    </Compile>
     <Compile Include="Configuration\RetentionPolicy.feature.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Augurk.Specifications/Properties/AssemblyInfo.cs
+++ b/src/Augurk.Specifications/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -10,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Augurk.Specifications")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright © 2015 - 2017, Augurk")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +20,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e4c65cb7-8b5d-4530-9b22-a00a77d8cda9")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Augurk/Augurk.csproj
+++ b/src/Augurk/Augurk.csproj
@@ -43,6 +43,12 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/src/Augurk/Properties/AssemblyInfo.cs
+++ b/src/Augurk/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Augurk")]
-[assembly: AssemblyCopyright("Copyright 2014 - 2015, Mark Taling")]
+[assembly: AssemblyCopyright("Copyright 2014 - 2017, Augurk")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Augurk/Properties/AssemblyVersion.cs
+++ b/src/Augurk/Properties/AssemblyVersion.cs
@@ -9,6 +9,6 @@
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
-[assembly: AssemblyInformationalVersion("2.5.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
+[assembly: AssemblyInformationalVersion("2.5.1")]

--- a/src/Augurk/packages.config
+++ b/src/Augurk/packages.config
@@ -6,6 +6,7 @@
   <package id="AngularJS.Sanitize" version="1.5.8" targetFramework="net45" />
   <package id="bootstrap" version="3.3.7" targetFramework="net45" />
   <package id="jQuery" version="3.1.1" targetFramework="net45" />
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
@@ -15,5 +16,6 @@
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="ui-select" version="0.12.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR fixes an issue that occurred with clean installs of Augurk after the recent 2.5.0 release. The problem was caused by Lucene.net assembly being required earlier on, before it was written to disk. We've now added Lucene.net as an explicit dependency which avoids the issue.

Fixes #55 