### PR TITLE
Setup API versioning and re-enable Swagger UI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
     },
     "coverage-gutters.coverageFileNames": [
         "coverage.info",
-    ]
+    ],
+    "terminal.integrated.cwd": "src/Augurk"
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,9 @@ variables:
 
 steps:
 - task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.1.500'
+  displayName: 'Use .NET Core sdk 2.1.505'
   inputs:
-    version: 2.1.500
+    version: 2.1.505
 
 - script: |
     dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,9 +14,9 @@ variables:
 
 steps:
 - task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.1.505'
+  displayName: 'Use .NET Core sdk 2.1.506'
   inputs:
-    version: 2.1.505
+    version: 2.1.506
 
 - script: |
     dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50

--- a/src/Augurk.IntegrationTest/Augurk.IntegrationTest.csproj
+++ b/src/Augurk.IntegrationTest/Augurk.IntegrationTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Augurk.IntegrationTest/Augurk.IntegrationTest.csproj
+++ b/src/Augurk.IntegrationTest/Augurk.IntegrationTest.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Augurk.IntegrationTest/Augurk.IntegrationTest.csproj
+++ b/src/Augurk.IntegrationTest/Augurk.IntegrationTest.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Alba" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="RavenDB.TestDriver" Version="4.1.3" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" />

--- a/src/Augurk.IntegrationTest/TestBase.cs
+++ b/src/Augurk.IntegrationTest/TestBase.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Threading.Tasks;
 using Alba;
+using Augurk.Api;
 using Augurk.Entities;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
@@ -33,6 +34,21 @@ namespace Augurk.IntegrationTest
     public abstract class TestBase : RavenTestDriver
     {
         private readonly SystemUnderTestFixture _fixture;
+
+        /// <summary>
+        /// Pre-configures the RavenDb in memory test server.
+        /// </summary>
+        static TestBase()
+        {
+            string dotNetCoreVersion = EnvironmentUtils.GetNetCoreVersion();
+
+            RavenTestDriver.ConfigureServer(new TestServerOptions
+            {
+                FrameworkVersion = dotNetCoreVersion
+            });
+
+            Console.WriteLine($"Configured RavenDb in memory test driver to use version {dotNetCoreVersion} of .NET Core.");
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestBase" /> class.

--- a/src/Augurk.IntegrationTest/TestBase.cs
+++ b/src/Augurk.IntegrationTest/TestBase.cs
@@ -55,23 +55,6 @@ namespace Augurk.IntegrationTest
         }
 
         /// <summary>
-        /// Uploads the provided <paramref name="feature" /> through the API and stores it under the provided
-        /// <paramref name="productName" /> and <paramref name="groupName" />.
-        /// </summary>
-        /// <param name="feature">A <see cref="Feature" /> instance to upload.</param>
-        /// <param name="productName">Name of the product to upload the feature to.</param>
-        /// <param name="groupName">Name of the group to upload the feature to.</param>
-        protected async Task UploadFeature(Feature feature, string productName, string groupName)
-        {
-            await System.Scenario(_ =>
-            {
-                _.Post.Json(feature)
-                      .ToUrl(TestHelper.GenerateFeatureUrl(productName, groupName, feature.Title));
-                _.StatusCodeShouldBeOk();
-            });
-        }
-
-        /// <summary>
         /// Gets the <see cref="SystemUnderTest" />.
         /// </summary>
         protected SystemUnderTest System { get { return _fixture.System; }}

--- a/src/Augurk.IntegrationTest/TestHelper.cs
+++ b/src/Augurk.IntegrationTest/TestHelper.cs
@@ -1,7 +1,35 @@
+using Alba;
+using Augurk.Entities;
+
 namespace Augurk.IntegrationTest
 {
     public static class TestHelper
     {
+        public static SendExpression PostFeature(this Alba.Scenario scenario, Feature feature, string productName, string groupName)
+        {
+            return scenario.Post.Json(feature).ToUrl(GenerateFeatureUrl(productName, groupName, feature.Title));
+        }
+
+        public static SendExpression GetFeature(this Alba.Scenario scenario, string productName, string groupName, string title)
+        {
+            return scenario.Get.Url(GenerateFeatureUrl(productName, groupName, title));
+        }
+
+        public static SendExpression PutProductDescription(this Alba.Scenario scenario, string productName, string productDescription)
+        {
+            return scenario.Put.Text(productDescription).ToUrl(GenerateProductUrl(productName) + "/description");
+        }
+
+        public static SendExpression GetProductDescription(this Alba.Scenario scenario, string productName)
+        {
+            return scenario.Get.Url(GenerateProductUrl(productName) + "/description");
+        }
+
+        public static string GenerateProductUrl(string productName)
+        {
+            return $"/api/v2/products/{productName}";
+        }
+
         public static string GenerateFeatureUrl(string productName, string groupName, string title, string version = "0.0.0")
         {
             return $"/api/v2/products/{productName}/groups/{groupName}/features/{title}/versions/{version}";

--- a/src/Augurk.IntegrationTest/UploadScenarios.cs
+++ b/src/Augurk.IntegrationTest/UploadScenarios.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Augurk.Entities;
+using Xunit;
+using Alba;
+using System.Linq;
+using Shouldly;
+using System.Net;
+
+namespace Augurk.IntegrationTest
+{
+    /// <summary>
+    /// Contains integration tests related to upload scenario's (ie. feature files and pruduct descriptions).
+    /// </summary>
+    [Collection(nameof(SystemUnderTestCollection))]
+    public class UploadScenarios : TestBase
+    {
+        private const string productName = "MyProduct";
+        private const string groupName = "MyGroup";
+
+        /// <summary>
+        /// Initializes a new instance of hte <see cref="UploadScenarios" /> class.
+        /// </summary>
+        /// <param name="fixture">A <see cref="SystemUnderTestFixture" /> instance to use.</param>
+        public UploadScenarios(SystemUnderTestFixture fixture) : base(fixture)
+        {
+        }
+
+        /// <summary>
+        /// Tests that a feature can be uploaded and subsequently retrieved from the API.
+        /// </summary>
+        [Fact]
+        public async Task CanUploadFeature()
+        {
+            // Arrange
+            var expectedFeature = new Feature
+            {
+                Title = "A simple feature",
+                Description = "As a math idiot I want to add two numbers so that I can calculate the result"
+            };
+
+            // Act
+            await System.Scenario(_ =>
+            {
+                _.PostFeature(expectedFeature, productName, groupName);
+                _.StatusCodeShouldBe(HttpStatusCode.Accepted);
+            });
+            
+            var result = await System.Scenario(_ =>
+            {
+                _.GetFeature(productName, groupName, expectedFeature.Title);
+                _.StatusCodeShouldBeOk();
+            });
+
+            // Assert
+            var actualFeature = result.ResponseBody.ReadAsJson<Feature>();
+            actualFeature.Title.ShouldBe(expectedFeature.Title);
+            actualFeature.Description.ShouldBe(expectedFeature.Description);
+        }
+
+        /// <summary>
+        /// Tests that a description for a product can be uploaded and subsequently retrieved through the API.
+        /// </summary>
+        [Fact]
+        public async Task CanUploadProductDescription()
+        {
+            // Arrange
+            var expectedProductDescription = "# MyProduct";
+
+            // Act
+            await System.Scenario(_ =>
+            {
+                _.PutProductDescription(productName, expectedProductDescription);
+                _.StatusCodeShouldBeOk();
+            });
+
+            var result = await System.Scenario(_ =>
+            {
+                _.GetProductDescription(productName);
+                _.StatusCodeShouldBeOk();
+            });
+
+            // Assert
+            var actualProductDescription = result.ResponseBody.ReadAsText();
+            actualProductDescription.ShouldBe(expectedProductDescription);
+        }
+    }
+}

--- a/src/Augurk/Augurk.csproj
+++ b/src/Augurk/Augurk.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="1.0.163" />
     <PackageReference Include="NuGet.Versioning" Version="4.8.0" />

--- a/src/Augurk/Augurk.csproj
+++ b/src/Augurk/Augurk.csproj
@@ -19,10 +19,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="1.0.163" />
     <PackageReference Include="NuGet.Versioning" Version="4.8.0" />
     <PackageReference Include="RavenDB.Embedded" Version="4.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Augurk/Controllers/V1/BranchController.cs
+++ b/src/Augurk/Controllers/V1/BranchController.cs
@@ -22,6 +22,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Augurk.Api.Controllers
 {
+    [ApiVersion("1.0")]
+    [Route("api/branches")]
+    [Route("api/v{apiVersion:apiVersion}/branches")]
     public class BranchController : Controller
     {
         private readonly IProductManager _productManager;
@@ -31,7 +34,6 @@ namespace Augurk.Api.Controllers
             _productManager = productManager ?? throw new ArgumentNullException(nameof(productManager));
         }
 
-        [Route("api/branches")]
         [HttpGet]
         public async Task<IEnumerable<string>> GetAsync()
         {

--- a/src/Augurk/Controllers/V1/FeatureController.cs
+++ b/src/Augurk/Controllers/V1/FeatureController.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Augurk.Api.Controllers
 {
+    [ApiVersion("1.0")]
     public class FeatureController : Controller
     {
         private const string UNKNOWN_VERSION = "0.0.0";

--- a/src/Augurk/Controllers/V1/TagController.cs
+++ b/src/Augurk/Controllers/V1/TagController.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Augurk.Api.Controllers
 {
+    [ApiVersion("1.0")]
     [ApiExplorerSettings(IgnoreApi = true)]
     public class TagController : Controller
     {

--- a/src/Augurk/Controllers/V2/AnalysisController.cs
+++ b/src/Augurk/Controllers/V2/AnalysisController.cs
@@ -26,7 +26,8 @@ namespace Augurk.Api.Controllers.V2
     /// <summary>
     /// ApiController for publishing analysis results.
     /// </summary>
-    [Route("api/v2/products/{productName}/versions/{version}/analysis")]
+    [ApiVersion("2.0")]
+    [Route("api/v{apiVersion:apiVersion}/products/{productName}/versions/{productVersion}/analysis")]
     public class AnalysisController : Controller
     {
         private readonly IAnalysisReportManager _analysisReportManager;

--- a/src/Augurk/Controllers/V2/AugurkController.cs
+++ b/src/Augurk/Controllers/V2/AugurkController.cs
@@ -25,7 +25,8 @@ namespace Augurk.Api.Controllers.V2
     /// <summary>
     /// ApiController for retrieving and persisting Augurk settings.
     /// </summary>
-    [Route("api/v2")]
+    [ApiVersion("2.0")]
+    [Route("api/v{version:apiVersion}")]
     [ApiExplorerSettings(IgnoreApi = true)]
     public class AugurkController : Controller
     {

--- a/src/Augurk/Controllers/V2/DependencyController.cs
+++ b/src/Augurk/Controllers/V2/DependencyController.cs
@@ -22,7 +22,8 @@ using System.Threading.Tasks;
 
 namespace Augurk.Api.Controllers.V2
 {
-    [Route("api/v2/dependencies")]
+    [ApiVersion("2.0")]
+    [Route("api/v{apiVersion:apiVersion}/dependencies")]
     public class DependencyController : Controller
     {
         private readonly IDependencyManager _dependencyManager;

--- a/src/Augurk/Controllers/V2/FeatureController.cs
+++ b/src/Augurk/Controllers/V2/FeatureController.cs
@@ -30,7 +30,7 @@ namespace Augurk.Api.Controllers.V2
     /// </summary>
     [ApiVersion("2.0")]
     [Route("api/v{apiVersion:apiVersion}/products/{productName}/groups/{groupName}/features")]
-    public class FeatureV2Controller : Controller
+    public class FeatureController : Controller
     {
         private readonly IFeatureManager _featureManager;
         private readonly Analyzer _analyzer;
@@ -38,7 +38,7 @@ namespace Augurk.Api.Controllers.V2
         /// <summary>
         /// Initializes a new instance of the <see cref="FeatureV2Controller"/>.
         /// </summary>
-        public FeatureV2Controller(IFeatureManager featureManager, IAnalysisReportManager analysisReportManager)
+        public FeatureController(IFeatureManager featureManager, IAnalysisReportManager analysisReportManager)
         {
             _featureManager = featureManager ?? throw new ArgumentNullException(nameof(featureManager));
             _analyzer = new Analyzer(_featureManager, analysisReportManager);

--- a/src/Augurk/Controllers/V2/FeatureV2Controller.cs
+++ b/src/Augurk/Controllers/V2/FeatureV2Controller.cs
@@ -28,7 +28,8 @@ namespace Augurk.Api.Controllers.V2
     /// <summary>
     /// ApiController for retrieving the available features.
     /// </summary>
-    [Route("api/v2/products/{productName}/groups/{groupName}/features")]
+    [ApiVersion("2.0")]
+    [Route("api/v{apiVersion:apiVersion}/products/{productName}/groups/{groupName}/features")]
     public class FeatureV2Controller : Controller
     {
         private readonly IFeatureManager _featureManager;

--- a/src/Augurk/Controllers/V2/GroupsController.cs
+++ b/src/Augurk/Controllers/V2/GroupsController.cs
@@ -26,7 +26,8 @@ namespace Augurk.Api.Controllers.V2
     /// <summary>
     /// ApiController for retrieving the available groups of related features within a product.
     /// </summary>
-    [Route("api/v2/products/{productName}/groups")]
+    [ApiVersion("2.0")]
+    [Route("api/v{apiVersion:apiVersion}/products/{productName}/groups")]
     public class GroupsController : Controller
     {
         private readonly IFeatureManager _featureManager;

--- a/src/Augurk/Controllers/V2/ProductsController.cs
+++ b/src/Augurk/Controllers/V2/ProductsController.cs
@@ -25,7 +25,8 @@ namespace Augurk.Api.Controllers.V2
     /// <summary>
     /// ApiController for retrieving the available products.
     /// </summary>
-    [Route("api/v2/products")]
+    [ApiVersion("2.0")]
+    [Route("api/v{apiVersion:apiVersion}/products")]
     public class ProductsController : Controller
     {
         private readonly IProductManager _productsManager;

--- a/src/Augurk/Controllers/V2/ProductsController.cs
+++ b/src/Augurk/Controllers/V2/ProductsController.cs
@@ -19,6 +19,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.IO;
+using System.Text;
 
 namespace Augurk.Api.Controllers.V2
 {
@@ -63,9 +65,13 @@ namespace Augurk.Api.Controllers.V2
         /// </summary>
         [Route("{productName}/description")]
         [HttpPut]
-        public async Task PutProductDescriptionAsync(string productName, [FromBody]string descriptionMarkdown)
+        public async Task PutProductDescriptionAsync(string productName)
         {
-            await _productsManager.InsertOrUpdateProductDescriptionAsync(productName, descriptionMarkdown);
+            using (StreamReader reader = new StreamReader(Request.Body, Encoding.UTF8))
+            {
+                string descriptionMarkdown = await reader.ReadToEndAsync();
+                await _productsManager.InsertOrUpdateProductDescriptionAsync(productName, descriptionMarkdown);
+            }
         }
 
         /// <summary>

--- a/src/Augurk/Controllers/VersionController.cs
+++ b/src/Augurk/Controllers/VersionController.cs
@@ -22,6 +22,7 @@ namespace Augurk.Api.Controllers
     /// <summary>
     /// ApiController for retrieving the currently installed Augurk version.
     /// </summary>
+    [ApiVersionNeutral]
     [Route("api/version")]
     public class VersionController : Controller
     {

--- a/src/Augurk/Startup.cs
+++ b/src/Augurk/Startup.cs
@@ -35,6 +35,7 @@ namespace Augurk
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddApiVersioning(options => options.AssumeDefaultVersionWhenUnspecified = true);
             services.AddRavenDb();
             services.AddManagers();
         }

--- a/src/Augurk/Startup.cs
+++ b/src/Augurk/Startup.cs
@@ -17,8 +17,10 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace Augurk
 {
@@ -34,14 +36,40 @@ namespace Augurk
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            // Add core MVC services and setup the versioned API explorer
+            services.AddMvcCore()
+                    .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
+                    .AddVersionedApiExplorer(options =>
+                    {
+                        options.GroupNameFormat = "'v'VVV";
+                        options.SubstituteApiVersionInUrl = true;
+                    });
+            
+            // Add the rest of the MVC stack (which we apparently need for now)
+            services.AddMvc();
+
+            // Setup API versioning
             services.AddApiVersioning(options => options.AssumeDefaultVersionWhenUnspecified = true);
+
+            // Add generation of Swagger documents
+            services.AddSwaggerGen(options =>
+            {
+                var provider = services.BuildServiceProvider().GetRequiredService<IApiVersionDescriptionProvider>();
+                foreach (var description in provider.ApiVersionDescriptions)
+                {
+                    options.SwaggerDoc(description.GroupName, CreateInfoForApiVersion(description));
+                }
+            });
+
+            // Setup RavenDB (Embedded)
             services.AddRavenDb();
+
+            // Add our own managers
             services.AddManagers();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApiVersionDescriptionProvider provider)
         {
             if (env.IsDevelopment())
             {
@@ -55,6 +83,36 @@ namespace Augurk
             app.UseHttpsRedirection();
             app.UseMvc();
             app.UseFileServer();
+
+            // Add Swagger support at the appropriate endpoints
+            app.UseSwagger(options => options.RouteTemplate = "doc/api/{documentName}");
+            app.UseSwaggerUI(options =>
+            {
+                options.RoutePrefix = "doc/ui";
+
+                foreach (var description in provider.ApiVersionDescriptions)
+                {
+                    options.SwaggerEndpoint($"/doc/api/{description.GroupName}", description.GroupName.ToUpperInvariant());
+                }
+            });
+        }
+
+        static Info CreateInfoForApiVersion(ApiVersionDescription description)
+        {
+            var info = new Info()
+            {
+                Version = description.ApiVersion.ToString(),
+                Title = description.GroupName.ToUpperInvariant() == "V1" ? 
+                    "Augurk Branch based API" : 
+                    "Augurk Product based API",
+            };
+
+            if (description.IsDeprecated)
+            {
+                info.Description += " This API version has been deprecated.";
+            }
+
+            return info;
         }
     }
 }

--- a/src/Augurk/Startup.cs
+++ b/src/Augurk/Startup.cs
@@ -45,7 +45,9 @@ namespace Augurk
                         options.SubstituteApiVersionInUrl = true;
                     });
             
-            // Add the rest of the MVC stack (which we apparently need for now)
+            // Add the rest of the MVC stack so we can use API controllers
+            // Note: This will probably change in .NET Core 3.0 where we can more finely grained specify
+            //       the parts of ASP.NET Core that we want to use.
             services.AddMvc();
 
             // Setup API versioning

--- a/src/Augurk/wwwroot/templates/configuration.html
+++ b/src/Augurk/wwwroot/templates/configuration.html
@@ -116,7 +116,7 @@
         <div class="panel-heading">Integration</div>
         <div class="panel-body">
             <div style="margin-top: -12px; margin-bottom: 12px;">
-                <p><em>Augurk exposes several APIs to enable integration in your own tools: <a href="/doc/ui/index?urls.primaryName=doc%2Fapi%2FV2">Go to documentation.</a></em></p>
+                <p><em>Augurk exposes several APIs to enable integration in your own tools: <a href="/doc/ui/index.html?urls.primaryName=V2">Go to documentation.</a></em></p>
                 <p>Of course, the easiest way to interact with the Augurk APIs is through the commandline tool which is available on NuGet: <a href="https://www.nuget.org/packages/Augurk.CommandLine/">https://www.nuget.org/packages/Augurk.CommandLine/</a>.</p>
                 <p>Users of <strong>Microsoft &reg; Visual Studio Team Services</strong> or <strong>Microsoft &reg; Team Foundation Server</strong> can also use the Augurk build integration: <a href="https://marketplace.visualstudio.com/items?itemName=augurk.augurk">https://marketplace.visualstudio.com/items?itemName=augurk.augurk</a>.</p>
             </div>


### PR DESCRIPTION
In this PR we've re-enabled Swagger UI after porting to .NET Core, which required some new setup. We've also setup proper versioning of the Augurk API so we can more easily support different versions, which couldn't be done previously with .NET Framework.

Additionally some integration tests were made that test Augurk through its API to have a higher level of confidence for future changes. For example, after porting to .NET Core, the functionality to upload a product description was broken. There's now a test for this, and the bug was fixed.

This will probably be the last set of big changes as we prepare an Augurk 3.0 release, which will support .NET Core.