### PR TITLE
Add Dockerfile and associated build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+**/img/
+
+# files
+Dockerfile*
+**/*.trx
+**/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
+WORKDIR /app
+
+# copy external library
+COPY extLib /extLib
+
+# copy csproj and restore as distinct layers
+COPY src/*.sln .
+COPY src/**/*.csproj ./
+RUN for file in $(ls *.csproj); do mkdir -p ${file%.*}/ && mv $file ${file%.*}/; done
+RUN dotnet restore
+
+# copy everything else and build app
+COPY src/. ./
+WORKDIR /app
+RUN dotnet publish -c Release -o out
+
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS runtime
+WORKDIR /app
+COPY --from=build /app/Augurk/out ./
+ENTRYPOINT ["dotnet", "Augurk.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
+ARG Version
+ARG InformationalVersion
 WORKDIR /app
 
 # copy external library
@@ -13,7 +15,7 @@ RUN dotnet restore
 # copy everything else and build app
 COPY src/. ./
 WORKDIR /app
-RUN dotnet publish -c Release -o out
+RUN dotnet publish /p:Version=$Version /p:InformationalVersion=$InformationalVersion -c Release -o out
 
 # build unit test stage
 FROM build AS unit-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,17 @@ COPY src/. ./
 WORKDIR /app
 RUN dotnet publish -c Release -o out
 
+# build unit test stage
+FROM build AS unit-tests
+WORKDIR /app/Augurk.Test
+ENTRYPOINT [ "dotnet", "test", "--logger:trx" ]
 
+# build integration test stage
+FROM build AS integration-tests
+WORKDIR /app/Augurk.IntegrationTest
+ENTRYPOINT [ "dotnet", "test", "--logger:trx" ]
+
+# build output image
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS runtime
 WORKDIR /app
 COPY --from=build /app/Augurk/out ./

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -132,7 +132,7 @@ jobs:
       inputs:
         command: Build an image
         imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(prerelease)'
-        arguments: '--pull'
+        arguments: '--pull --build-arg Version=$(GitVersion.MajorMinorPatch) --build-arg InformationalVersion=$(GitVersion.InformationalVersion)'
     - task: Docker@1
       displayName: 'Push runtime image'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - task: GitVersion@4
+    - task: GitVersion@5
       displayName: 'Determine version'
       inputs:
         updateAssemblyInfo: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,7 @@ jobs:
       inputs:
         command: Run an image
         imageName: '$(imageName):unit-tests'
+        runInBackground: false
         arguments: '--rm'
         volumes:
           '$(Build.ArtifactStagingDirectory):/app/Augurk.Test/TestResults'
@@ -107,6 +108,7 @@ jobs:
       inputs:
         command: Run an image
         imageName: '$(imageName):integration-tests'
+        runInBackground: false
         arguments: '--rm'
         volumes: 
           '$(Build.ArtifactStagingDirectory):/app/Augurk.IntegrationTest/TestResults'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,10 +133,18 @@ jobs:
         command: Build an image
         imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(prerelease)'
         arguments: '--pull --build-arg Version=$(GitVersion.MajorMinorPatch) --build-arg InformationalVersion=$(GitVersion.InformationalVersion)'
+        includeLatestTag: true
     - task: Docker@1
-      displayName: 'Push runtime image'
+      displayName: 'Push runtime image (tagged)'
       inputs:
         command: Push an image
         imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(prerelease)'
+        containerregistrytype: Container Registry
+        dockerRegistryEndpoint: 'Docker Hub'
+    - task: Docker@1
+      displayName: 'Push runtime image (latest)'
+      inputs:
+        command: Push an image
+        imageName: '$(imageName):latest'
         containerregistrytype: Container Registry
         dockerRegistryEndpoint: 'Docker Hub'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,10 @@ jobs:
         dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50
         dotnet-gitversion /output buildserver
       displayName: Set version
+    - script: |
+        echo '##vso[task.setvariable variable=prerelease]-prerelease'
+      displayName: Set prerelease tag
+      condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
     - task: Docker@1
       displayName: 'Build unit test image'
@@ -127,5 +131,5 @@ jobs:
       displayName: 'Build runtime image'
       inputs:
         command: Build an image
-        imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(GitVersion.PreReleaseTagWithDash)'
+        imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(prerelease)'
         arguments: '--pull'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - task: GitVersion@5
+    - task: GitVersionNetCore@4
       displayName: 'Determine version'
       inputs:
         updateAssemblyInfo: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
       inputs:
         command: Build an image
         imageName: '$(imageName):unit-tests'
-        arguments: '--pull --target unit-tests'
+        arguments: '--pull --target unit-tests --build-arg Version=$(GitVersion.MajorMinorPatch) --build-arg InformationalVersion=$(GitVersion.InformationalVersion)'
     - task: Docker@1
       displayName: 'Run unit tests'
       inputs:
@@ -107,7 +107,7 @@ jobs:
       inputs:
         command: Build an image
         imageName: '$(imageName):integration-tests'
-        arguments: '--pull --target integration-tests'
+        arguments: '--pull --target integration-tests --build-arg Version=$(GitVersion.MajorMinorPatch) --build-arg InformationalVersion=$(GitVersion.InformationalVersion)'
     - task: Docker@1
       displayName: 'Run integration tests'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,10 +74,10 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - task: GitVersionNetCore@5
-      displayName: 'Determine version'
-      inputs:
-        updateAssemblyInfo: true
+    - script: |
+        dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50
+        dotnet-gitversion /output buildserver
+      displayName: Set version
     - task: Docker@1
       displayName: 'Build unit test image'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
-    - task: GitVersionNetCore@4
+    - task: GitVersionNetCore@5
       displayName: 'Determine version'
       inputs:
         updateAssemblyInfo: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
         imageName: '$(imageName):unit-tests'
         runInBackground: false
         volumes:
-          '$(Build.ArtifactStagingDirectory):/app/Augurk.Test/TestResults'
+          '$(System.DefaultWorkingDirectory):/app/Augurk.Test/TestResults'
     - task: Docker@1
       displayName:  'Build integration test image'
       inputs:
@@ -109,7 +109,7 @@ jobs:
         imageName: '$(imageName):integration-tests'
         runInBackground: false
         volumes: 
-          '$(Build.ArtifactStagingDirectory):/app/Augurk.IntegrationTest/TestResults'
+          '$(System.DefaultWorkingDirectory):/app/Augurk.IntegrationTest/TestResults'
     - task: PublishTestResults@2
       displayName: 'Publish test results'
       inputs:
@@ -117,7 +117,7 @@ jobs:
         buildPlatform: 'Docker'
         testResultsFormat: VSTest
         testResultsFiles: '**/*.trx'
-        searchFolder: $)Build.ArtifactStagingDirectory)
+        failTaskOnFailedTests: true
     - task: Docker@1
       displayName: 'Build runtime image'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,10 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
   steps:
+    - task: DotNetCoreInstaller@0
+      displayName: 'Use .NET Core sdk 2.1.506'
+      inputs:
+        version: 2.1.506
     - script: |
         dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50
         dotnet-gitversion /output buildserver

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,5 +127,5 @@ jobs:
       displayName: 'Build runtime image'
       inputs:
         command: Build an image
-        imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)'
+        imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(GitVersion.PreReleaseTagWithDash)'
         arguments: '--pull'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,10 +53,6 @@ steps:
     zipAfterPublish: true
   displayName: dotnet publish
 
-# - script: |
-#     dotnet publish Augurk --configuration $(buildConfiguration) --output $BUILD_ARTIFACTSTAGINGDIRECTORY /p:Version=$GITVERSION_MAJORMINORPATCH /p:InformationalVersion=$GITVERSION_INFORMATIONALVERSION
-#   workingDirectory: 'src'
-
 - task: PublishBuildArtifacts@1
 
 - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,6 @@ jobs:
         command: Run an image
         imageName: '$(imageName):unit-tests'
         runInBackground: false
-        arguments: '--rm'
         volumes:
           '$(Build.ArtifactStagingDirectory):/app/Augurk.Test/TestResults'
     - task: Docker@1
@@ -109,7 +108,6 @@ jobs:
         command: Run an image
         imageName: '$(imageName):integration-tests'
         runInBackground: false
-        arguments: '--rm'
         volumes: 
           '$(Build.ArtifactStagingDirectory):/app/Augurk.IntegrationTest/TestResults'
     - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,3 +133,10 @@ jobs:
         command: Build an image
         imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(prerelease)'
         arguments: '--pull'
+    - task: Docker@1
+      displayName: 'Push runtime image'
+      inputs:
+        command: Push an image
+        imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)$(prerelease)'
+        containerregistrytype: Container Registry
+        dockerRegistryEndpoint: 'Docker Hub'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,64 +4,119 @@
 # https://docs.microsoft.com/vsts/pipelines/apps/windows/dot-net
 
 # Build ASP.NET Core project using Azure Pipelines
-# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core?view=vsts
-
-pool:
-  vmImage: 'Ubuntu 16.04'
-  
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core?view=vsts  
 variables:
   buildConfiguration: 'Release'
 
-steps:
-- task: DotNetCoreInstaller@0
-  displayName: 'Use .NET Core sdk 2.1.506'
-  inputs:
-    version: 2.1.506
+jobs:
+- job: netcore
+  displayName: .NET Core Framework Dependent
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+  - task: DotNetCoreInstaller@0
+    displayName: 'Use .NET Core sdk 2.1.506'
+    inputs:
+      version: 2.1.506
 
-- script: |
-    dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50
-    dotnet-gitversion /output buildserver
-  displayName: Set version
+  - script: |
+      dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50
+      dotnet-gitversion /output buildserver
+    displayName: Set version
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: restore
-    projects: src/Augurk.sln
-    workingDirectory: 'src'
-  displayName: dotnet restore
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: restore
+      projects: src/Augurk.sln
+      workingDirectory: 'src'
+    displayName: dotnet restore
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: build
-    workingDirectory: 'src'
-    configuration: $(buildConfiguration)
-    arguments: '/p:Version=$(GitVersion.MajorMinorPatch) /p:InformationalVersion=$(GitVersion.InformationalVersion)'
-  displayName: dotnet build
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: build
+      workingDirectory: 'src'
+      configuration: $(buildConfiguration)
+      arguments: '/p:Version=$(GitVersion.MajorMinorPatch) /p:InformationalVersion=$(GitVersion.InformationalVersion)'
+    displayName: dotnet build
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: test
-    workingDirectory: 'src'
-    configuration: $(buildConfiguration)
-  displayName: dotnet test
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      workingDirectory: 'src'
+      configuration: $(buildConfiguration)
+    displayName: dotnet test
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: publish
-    publishWebProjects: True
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(GitVersion.MajorMinorPatch) /p:InformationalVersion=$(GitVersion.InformationalVersion)'
-    zipAfterPublish: true
-  displayName: dotnet publish
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: publish
+      publishWebProjects: True
+      arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) /p:Version=$(GitVersion.MajorMinorPatch) /p:InformationalVersion=$(GitVersion.InformationalVersion)'
+      zipAfterPublish: true
+    displayName: dotnet publish
 
-- task: PublishBuildArtifacts@1
+  - task: PublishBuildArtifacts@1
 
-- task: CopyFiles@2
-  inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/Augurk.Specifications
-    contents: "**/?(*.feature|*.md)"
-    targetFolder: $(Build.ArtifactStagingDirectory)/features
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Build.SourcesDirectory)/src/Augurk.Specifications
+      contents: "**/?(*.feature|*.md)"
+      targetFolder: $(Build.ArtifactStagingDirectory)/features
 
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: $(Build.ArtifactStagingDirectory)/features
-    artifactName: features
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: $(Build.ArtifactStagingDirectory)/features
+      artifactName: features
+
+- job: docker
+  displayName: Docker Image
+  variables:
+    imageName: augurk/augurk
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+    - task: GitVersion@4
+      displayName: 'Determine version'
+      inputs:
+        updateAssemblyInfo: true
+    - task: Docker@1
+      displayName: 'Build unit test image'
+      inputs:
+        command: Build an image
+        imageName: '$(imageName):unit-tests'
+        arguments: '--pull --target unit-tests'
+    - task: Docker@1
+      displayName: 'Run unit tests'
+      inputs:
+        command: Run an image
+        imageName: '$(imageName):unit-tests'
+        arguments: '--rm'
+        volumes:
+          '$(Build.ArtifactStagingDirectory):/app/Augurk.Test/TestResults'
+    - task: Docker@1
+      displayName:  'Build integration test image'
+      inputs:
+        command: Build an image
+        imageName: '$(imageName):integration-tests'
+        arguments: '--pull --target integration-tests'
+    - task: Docker@1
+      displayName: 'Run integration tests'
+      inputs:
+        command: Run an image
+        imageName: '$(imageName):integration-tests'
+        arguments: '--rm'
+        volumes: 
+          '$(Build.ArtifactStagingDirectory):/app/Augurk.IntegrationTest/TestResults'
+    - task: PublishTestResults@2
+      displayName: 'Publish test results'
+      inputs:
+        buildConfiguration: $(BuildConfiguration)
+        buildPlatform: 'Docker'
+        testResultsFormat: VSTest
+        testResultsFiles: '**/*.trx'
+        searchFolder: $)Build.ArtifactStagingDirectory)
+    - task: Docker@1
+      displayName: 'Build runtime image'
+      inputs:
+        command: Build an image
+        imageName: '$(imageName):$(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)'
+        arguments: '--pull'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,7 @@ jobs:
         dotnet tool install --global GitVersion.Tool --version 4.0.1-beta1-50
         dotnet-gitversion /output buildserver
       displayName: Set version
+
     - task: Docker@1
       displayName: 'Build unit test image'
       inputs:
@@ -94,8 +95,9 @@ jobs:
         command: Run an image
         imageName: '$(imageName):unit-tests'
         runInBackground: false
-        volumes:
-          '$(System.DefaultWorkingDirectory):/app/Augurk.Test/TestResults'
+        volumes: 
+          '$(Build.ArtifactStagingDirectory):/app/Augurk.Test/TestResults/'
+
     - task: Docker@1
       displayName:  'Build integration test image'
       inputs:
@@ -109,7 +111,8 @@ jobs:
         imageName: '$(imageName):integration-tests'
         runInBackground: false
         volumes: 
-          '$(System.DefaultWorkingDirectory):/app/Augurk.IntegrationTest/TestResults'
+          '$(Build.ArtifactStagingDirectory):/app/Augurk.IntegrationTest/TestResults/'
+
     - task: PublishTestResults@2
       displayName: 'Publish test results'
       inputs:
@@ -117,7 +120,9 @@ jobs:
         buildPlatform: 'Docker'
         testResultsFormat: VSTest
         testResultsFiles: '**/*.trx'
+        searchFolder: '$(Build.ArtifactStagingDirectory)'
         failTaskOnFailedTests: true
+
     - task: Docker@1
       displayName: 'Build runtime image'
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ jobs:
         dotnet-gitversion /output buildserver
       displayName: Set version
     - script: |
-        echo '##vso[task.setvariable variable=prerelease]-prerelease'
+        echo '##vso[task.setvariable variable=prerelease]-preview'
       displayName: Set prerelease tag
       condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 


### PR DESCRIPTION
A Dockerfile was added so that we can build Docker images for Augurk so that people can run Augurk very easily. Additionally the build pipeline was modified to not only produce a zip that can be used to run Augurk, but also build the Docker image and publish it to [Docker Hub](https://hub.docker.com/r/augurk/augurk).

Note that the build will always publish the image straight to Docker Hub, without going through a release pipeline. It will be tagged with the major.minor.patch based on GitVersion and a -preview postfix unless it is a build on the master branch. Once we have a stable 3.0 version we should probably make clear to users that the -preview tag is basically the latest greatest.