### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Augurk
 ======
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/389/augurk-gherkin-documentation-csharp/badge)](https://builtwithdot.net/project/389/augurk-gherkin-documentation-csharp)
 
 Augurk is an always improving, open source, living documentation system designed to get maximum value out of [Gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin)-based specifications. By continuously listening to the struggles and desires of various agile teams, Augurk aims to be the most natural fit for anyone wishing to publish their living documentation.
 


### PR DESCRIPTION
Since Augurk is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for Augurk to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)